### PR TITLE
version scheme + url + dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    target-branch: "master"
+    schedule:
+      interval: "daily"
+

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@ under the License.
   
   <groupId>org.apache.netbeans</groupId>
   <artifactId>nbpackage</artifactId>
-  <version>1.0-beta2</version>
+  <version>1.0-beta3-SNAPSHOT</version>
   <packaging>jar</packaging>
   
   <name>Apache NetBeans NBPackage</name>
@@ -36,9 +36,9 @@ under the License.
   <description>Apache NetBeans packaging utility.</description>
   
   <scm>
-    <connection>scm:git:https://gitbox.apache.org/repos/asf/netbeans-tools.git</connection>
-    <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/netbeans-tools.git</developerConnection>
-    <url>https://github.com/apache/netbeans-tools</url>
+    <connection>scm:git:https://gitbox.apache.org/repos/asf/netbeans-nbpackage.git</connection>
+    <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/netbeans-nbpackage.git</developerConnection>
+    <url>https://github.com/apache/netbeans-nbpackage</url>
   </scm>
   
   <dependencies>


### PR DESCRIPTION
use SNAPSHOT to comply with maven pratices (ease of release)
add dependabot to help knowing what change in dep
update url.