### PR TITLE
testing package of notice

### DIFF
--- a/src/assembly/_dist.xml
+++ b/src/assembly/_dist.xml
@@ -31,6 +31,9 @@ under the License.
         <include>README*</include>
         <include>LICENSE*</include>
       </includes>
+      <excludes>
+        <exclude>NOTICE*</exclude>
+      </excludes>
     </fileSet>
   </fileSets>
   <files>

--- a/src/assembly/bin/BINARY_NOTICE
+++ b/src/assembly/bin/BINARY_NOTICE
@@ -1,5 +1,5 @@
 Apache NetBeans Packager (NBPackage)
-Copyright 2022 The Apache Software Foundation
+Copyright 2023 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).


### PR DESCRIPTION
this is only on step.
NOTICE left intact BINARY_NOTICE changed to 2023 to see what's get in.

To me seems bin are ok, srcs are ok but read from NOTICE

jar is reading from the bundled apache jar.