### PR TITLE
Refactor AbstractPackagerTask to support image filtering

### DIFF
--- a/src/main/java/org/apache/netbeans/nbpackage/AbstractPackagerTask.java
+++ b/src/main/java/org/apache/netbeans/nbpackage/AbstractPackagerTask.java
@@ -147,11 +147,11 @@ public abstract class AbstractPackagerTask implements Packager.Task {
                 .map(Path::toAbsolutePath)
                 .orElse(null);
         if (mergeSource != null) {
-            Path rootDir = calculateRootPath(image, appDir);
+            Path rootDir = calculateRootPath(image);
             if (Files.isDirectory(mergeSource)) {
-                processMergeFromDirectory(mergeSource, image, rootDir, appDir);
+                processMergeFromDirectory(mergeSource, image, rootDir);
             } else if (Files.isRegularFile(mergeSource)) {
-                processMergeFromArchive(mergeSource, image, rootDir, appDir);
+                processMergeFromArchive(mergeSource, image, rootDir);
             } else {
                 throw new IllegalArgumentException(mergeSource.toString());
             }
@@ -304,11 +304,10 @@ public abstract class AbstractPackagerTask implements Packager.Task {
      * directory itself.
      *
      * @param image image path
-     * @param application application path
      * @return resolved root path
      * @throws Exception if unable to compute path
      */
-    protected Path calculateRootPath(Path image, Path application) throws Exception {
+    protected Path calculateRootPath(Path image) throws Exception {
         return image;
     }
 
@@ -374,15 +373,15 @@ public abstract class AbstractPackagerTask implements Packager.Task {
     }
 
     private void processMergeFromArchive(Path archive, Path image,
-            Path rootDir, Path appDir) throws IOException {
+            Path rootDir) throws IOException {
         var tmp = Files.createTempDirectory("nbpackageMergeExtract");
         FileUtils.extractArchive(archive, tmp);
-        processMergeFromDirectory(tmp, image, rootDir, appDir);
+        processMergeFromDirectory(tmp, image, rootDir);
         FileUtils.deleteFiles(tmp);
     }
 
     private void processMergeFromDirectory(Path sourceDir, Path imageDir,
-            Path rootDir, Path appDir) throws IOException {
+            Path rootDir) throws IOException {
         try (var stream = Files.list(sourceDir)) {
             var files = stream.sorted().collect(Collectors.toList());
             for (Path file : files) {
@@ -391,8 +390,6 @@ public abstract class AbstractPackagerTask implements Packager.Task {
                     Path dest;
                     if ("__ROOT".equals(name)) {
                         dest = rootDir;
-                    } else if ("__APP".equals(name)) {
-                        dest = appDir;
                     } else {
                         dest = imageDir.resolve(name);
                         Files.createDirectories(dest);

--- a/src/main/java/org/apache/netbeans/nbpackage/AbstractPackagerTask.java
+++ b/src/main/java/org/apache/netbeans/nbpackage/AbstractPackagerTask.java
@@ -286,6 +286,7 @@ public abstract class AbstractPackagerTask implements Packager.Task {
         }
         var image = images.get(0);
         FileUtils.moveFiles(image, destDir);
+        FileUtils.deleteFiles(tmp);
     }
 
     private void copyAppFromDirectory(Path input, Path destDir) throws IOException {
@@ -310,6 +311,7 @@ public abstract class AbstractPackagerTask implements Packager.Task {
         }
         var java = runtimes.get(0);
         FileUtils.moveFiles(java, destDir);
+        FileUtils.deleteFiles(tmp);
     }
 
     private void copyRuntimeFromDirectory(Path runtime, Path destDir) throws IOException {

--- a/src/main/java/org/apache/netbeans/nbpackage/FileUtils.java
+++ b/src/main/java/org/apache/netbeans/nbpackage/FileUtils.java
@@ -347,7 +347,7 @@ public class FileUtils {
         }
     }
 
-    private static void ensureWritable(Path path) throws IOException {
+    static void ensureWritable(Path path) throws IOException {
         if (Files.isWritable(path) || Files.isSymbolicLink(path)) {
             return;
         }

--- a/src/main/java/org/apache/netbeans/nbpackage/NBPackage.java
+++ b/src/main/java/org/apache/netbeans/nbpackage/NBPackage.java
@@ -101,6 +101,22 @@ public final class NBPackage {
             MESSAGES.getString("option.description.default"),
             MESSAGES.getString("option.description.help"));
 
+    /**
+     * Option definition for a merge source (zip or directory path) of
+     * additional files to be added to the final image.
+     */
+    public static final Option<Path> PACKAGE_MERGE = Option.ofPath(
+            "package.merge",
+            MESSAGES.getString("option.merge.help"));
+
+    /**
+     * Option definition for a glob pattern of files to remove from the final
+     * image.
+     */
+    public static final Option<String> PACKAGE_REMOVE = Option.ofString(
+            "package.remove",
+            MESSAGES.getString("option.remove.help"));
+
 // @TODO generate list from service loader if modularizing
     private static final List<Packager> PACKAGERS = List.of(
             new AppImagePackager(),
@@ -113,7 +129,8 @@ public final class NBPackage {
 
     private static final List<Option<?>> GLOBAL_OPTIONS
             = List.of(PACKAGE_NAME, PACKAGE_VERSION, PACKAGE_TYPE, PACKAGE_RUNTIME,
-                    PACKAGE_DESCRIPTION, PACKAGE_PUBLISHER, PACKAGE_URL);
+                    PACKAGE_DESCRIPTION, PACKAGE_PUBLISHER, PACKAGE_URL,
+                    PACKAGE_MERGE, PACKAGE_REMOVE);
 
     private NBPackage() {
         // no op

--- a/src/main/java/org/apache/netbeans/nbpackage/appimage/AppImageTask.java
+++ b/src/main/java/org/apache/netbeans/nbpackage/appimage/AppImageTask.java
@@ -99,20 +99,20 @@ class AppImageTask extends AbstractPackagerTask {
     }
 
     @Override
-    protected String imageName(Path input) throws Exception {
+    protected String calculateImageName(Path input) throws Exception {
         var version = sanitize(context().getValue(NBPackage.PACKAGE_VERSION).orElse(""));
         return sanitize(context().getValue(NBPackage.PACKAGE_NAME).orElseThrow())
                 + (version.isBlank() ? ".AppDir" : "-" + version + ".AppDir");
     }
 
     @Override
-    protected Path applicationDirectory(Path image) throws Exception {
+    protected Path calculateAppPath(Path image) throws Exception {
         // change name to launcher name later
         return image.resolve("usr").resolve("lib").resolve("APPDIR");
     }
 
     @Override
-    protected Path runtimeDirectory(Path image, Path application) throws Exception {
+    protected Path calculateRuntimePath(Path image, Path application) throws Exception {
         return image.resolve("usr").resolve("lib").resolve("jdk");
     }
 

--- a/src/main/java/org/apache/netbeans/nbpackage/appimage/AppImageTask.java
+++ b/src/main/java/org/apache/netbeans/nbpackage/appimage/AppImageTask.java
@@ -40,7 +40,7 @@ class AppImageTask extends AbstractPackagerTask {
     }
 
     @Override
-    public void validateCreatePackage() throws Exception {
+    protected void checkPackageRequirements() throws Exception {
         Path tool = context().getValue(AppImagePackager.APPIMAGE_TOOL)
                 .orElseThrow(() -> new IllegalStateException(
                 AppImagePackager.MESSAGES.getString("message.noappimagetool")));
@@ -51,8 +51,7 @@ class AppImageTask extends AbstractPackagerTask {
     }
 
     @Override
-    public Path createImage(Path input) throws Exception {
-        var image = super.createImage(input);
+    protected void customizeImage(Path image) throws Exception {
         Path usrLib = image.resolve("usr").resolve("lib");
         String execName = findLauncher(
                 usrLib.resolve("APPDIR").resolve("bin"))
@@ -70,12 +69,10 @@ class AppImageTask extends AbstractPackagerTask {
         setupDesktopFile(image, execName);
         setupAppRunScript(image, execName);
 
-        return image;
-
     }
 
     @Override
-    public Path createPackage(Path image) throws Exception {
+    protected Path buildPackage(Path image) throws Exception {
         Path tool = context().getValue(AppImagePackager.APPIMAGE_TOOL)
                 .orElseThrow(() -> new IllegalStateException(
                 AppImagePackager.MESSAGES.getString("message.noappimagetool")))

--- a/src/main/java/org/apache/netbeans/nbpackage/deb/DebTask.java
+++ b/src/main/java/org/apache/netbeans/nbpackage/deb/DebTask.java
@@ -49,7 +49,7 @@ class DebTask extends AbstractPackagerTask {
     }
 
     @Override
-    public void validateCreateImage() throws Exception {
+    protected void checkImageRequirements() throws Exception {
         super.validateCreateImage();
         if (context().isImageOnly()) {
             validateTools(DPKG);
@@ -57,13 +57,12 @@ class DebTask extends AbstractPackagerTask {
     }
 
     @Override
-    public void validateCreatePackage() throws Exception {
+    protected void checkPackageRequirements() throws Exception {
         validateTools(DPKG, DPKG_DEB, FAKEROOT);
     }
 
     @Override
-    public Path createImage(Path input) throws Exception {
-        Path image = super.createImage(input);
+    protected void customizeImage(Path image) throws Exception {
         String pkgName = packageName();
 
         // @TODO support other installation bases
@@ -89,11 +88,10 @@ class DebTask extends AbstractPackagerTask {
         Files.createDirectories(DEBIAN);
         setupControlFile(DEBIAN);
 
-        return image;
     }
 
     @Override
-    public Path createPackage(Path image) throws Exception {
+    protected Path buildPackage(Path image) throws Exception {
         String targetName = image.getFileName().toString() + ".deb";
         Path target = context().destination().resolve(targetName).toAbsolutePath();
         if (Files.exists(target)) {

--- a/src/main/java/org/apache/netbeans/nbpackage/deb/DebTask.java
+++ b/src/main/java/org/apache/netbeans/nbpackage/deb/DebTask.java
@@ -108,12 +108,12 @@ class DebTask extends AbstractPackagerTask {
     }
 
     @Override
-    protected String imageName(Path input) throws Exception {
+    protected String calculateImageName(Path input) throws Exception {
         return packageName() + "_" + packageVersion() + "_" + packageArch();
     }
 
     @Override
-    protected Path applicationDirectory(Path image) throws Exception {
+    protected Path calculateAppPath(Path image) throws Exception {
         return image.resolve("usr").resolve("lib").resolve("APPDIR");
     }
 

--- a/src/main/java/org/apache/netbeans/nbpackage/innosetup/InnoSetupTask.java
+++ b/src/main/java/org/apache/netbeans/nbpackage/innosetup/InnoSetupTask.java
@@ -95,17 +95,17 @@ class InnoSetupTask extends AbstractPackagerTask {
     }
 
     @Override
-    protected String imageName(Path input) throws Exception {
-        return super.imageName(input) + "-InnoSetup";
+    protected String calculateImageName(Path input) throws Exception {
+        return super.calculateImageName(input) + "-InnoSetup";
     }
 
     @Override
-    protected Path applicationDirectory(Path image) throws Exception {
+    protected Path calculateAppPath(Path image) throws Exception {
         return image.resolve("APPDIR");
     }
 
     @Override
-    protected Path runtimeDirectory(Path image, Path application) throws Exception {
+    protected Path calculateRuntimePath(Path image, Path application) throws Exception {
         return application.resolve("jdk");
     }
 

--- a/src/main/java/org/apache/netbeans/nbpackage/innosetup/InnoSetupTask.java
+++ b/src/main/java/org/apache/netbeans/nbpackage/innosetup/InnoSetupTask.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.netbeans.nbpackage.AbstractPackagerTask;
 import org.apache.netbeans.nbpackage.ExecutionContext;
+import org.apache.netbeans.nbpackage.FileUtils;
 import org.apache.netbeans.nbpackage.NBPackage;
 import org.apache.netbeans.nbpackage.StringUtils;
 
@@ -59,7 +60,7 @@ class InnoSetupTask extends AbstractPackagerTask {
 
     @Override
     protected void finalizeImage(Path image) throws Exception {
-        String execName = findExecName(image.resolve("APPDIR").resolve("bin"));
+        String execName = findExecName(FileUtils.find(image, "*/bin").get(0));
         createInnoSetupScript(image, execName);
     }
 
@@ -110,6 +111,11 @@ class InnoSetupTask extends AbstractPackagerTask {
     @Override
     protected Path calculateRuntimePath(Path image, Path application) throws Exception {
         return application.resolve("jdk");
+    }
+
+    @Override
+    protected Path calculateRootPath(Path image) throws Exception {
+        return FileUtils.find(image, "*/bin").get(0).getParent();
     }
 
     private Path findLauncher(Path binDir) throws IOException {

--- a/src/main/java/org/apache/netbeans/nbpackage/innosetup/InnoSetupTask.java
+++ b/src/main/java/org/apache/netbeans/nbpackage/innosetup/InnoSetupTask.java
@@ -42,15 +42,14 @@ class InnoSetupTask extends AbstractPackagerTask {
     }
 
     @Override
-    public void validateCreatePackage() throws Exception {
+    protected void checkPackageRequirements() throws Exception {
         context().getValue(TOOL_PATH)
                 .orElseThrow(() -> new IllegalStateException(
                 MESSAGES.getString("message.noinnosetuptool")));
     }
 
     @Override
-    public Path createImage(Path input) throws Exception {
-        Path image = super.createImage(input);
+    protected void customizeImage(Path image) throws Exception {
         String execName = findExecName(image.resolve("APPDIR").resolve("bin"));
 
         Path appDir = image.resolve(execName);
@@ -59,12 +58,10 @@ class InnoSetupTask extends AbstractPackagerTask {
         setupIcons(image, execName);
         setupLicenseFile(image);
         createInnoSetupScript(image, execName);
-
-        return image;
     }
 
     @Override
-    public Path createPackage(Path image) throws Exception {
+    protected Path buildPackage(Path image) throws Exception {
         Path tool = context().getValue(TOOL_PATH)
                 .orElseThrow(() -> new IllegalStateException(
                 MESSAGES.getString("message.noinnosetuptool")))

--- a/src/main/java/org/apache/netbeans/nbpackage/innosetup/InnoSetupTask.java
+++ b/src/main/java/org/apache/netbeans/nbpackage/innosetup/InnoSetupTask.java
@@ -18,9 +18,7 @@
  */
 package org.apache.netbeans.nbpackage.innosetup;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -57,6 +55,11 @@ class InnoSetupTask extends AbstractPackagerTask {
 
         setupIcons(image, execName);
         setupLicenseFile(image);
+    }
+
+    @Override
+    protected void finalizeImage(Path image) throws Exception {
+        String execName = findExecName(image.resolve("APPDIR").resolve("bin"));
         createInnoSetupScript(image, execName);
     }
 
@@ -136,7 +139,7 @@ class InnoSetupTask extends AbstractPackagerTask {
             );
         }
     }
-    
+
     private void setupLicenseFile(Path image) throws IOException {
         var license = context().getValue(LICENSE_PATH).orElse(null);
         if (license == null) {

--- a/src/main/java/org/apache/netbeans/nbpackage/macos/AppBundleTask.java
+++ b/src/main/java/org/apache/netbeans/nbpackage/macos/AppBundleTask.java
@@ -109,12 +109,12 @@ class AppBundleTask extends AbstractPackagerTask {
     }
     
     @Override
-    protected String imageName(Path input) throws Exception {
-        return super.imageName(input) + "-macOS-app";
+    protected String calculateImageName(Path input) throws Exception {
+        return super.calculateImageName(input) + "-macOS-app";
     }
     
     @Override
-    protected Path applicationDirectory(Path image) throws Exception {
+    protected Path calculateAppPath(Path image) throws Exception {
         return image.resolve(getBundleName() + ".app")
                 .resolve("Contents")
                 .resolve("Resources")
@@ -122,7 +122,7 @@ class AppBundleTask extends AbstractPackagerTask {
     }
     
     @Override
-    protected Path runtimeDirectory(Path image, Path application) throws Exception {
+    protected Path calculateRuntimePath(Path image, Path application) throws Exception {
         return image.resolve(getBundleName() + ".app")
                 .resolve("Contents")
                 .resolve("Home");

--- a/src/main/java/org/apache/netbeans/nbpackage/macos/AppBundleTask.java
+++ b/src/main/java/org/apache/netbeans/nbpackage/macos/AppBundleTask.java
@@ -132,6 +132,11 @@ class AppBundleTask extends AbstractPackagerTask {
                 .resolve("Home");
     }
 
+    @Override
+    protected Path calculateRootPath(Path image) throws Exception {
+        return image.resolve(getBundleName() + ".app");
+    }
+
     String getBundleName() {
         if (bundleName == null) {
             var name = sanitize(context().getValue(NBPackage.PACKAGE_NAME).orElseThrow());

--- a/src/main/java/org/apache/netbeans/nbpackage/macos/AppBundleTask.java
+++ b/src/main/java/org/apache/netbeans/nbpackage/macos/AppBundleTask.java
@@ -52,7 +52,7 @@ class AppBundleTask extends AbstractPackagerTask {
     }
     
     @Override
-    public void validateCreatePackage() throws Exception {
+    protected void checkPackageRequirements() throws Exception {
         String[] cmds;
         if (context().getValue(MacOS.CODESIGN_ID).isEmpty()) {
             cmds = new String[] {"swift"};
@@ -63,8 +63,7 @@ class AppBundleTask extends AbstractPackagerTask {
     }
     
     @Override
-    public Path createImage(Path input) throws Exception {
-        Path image = super.createImage(input);
+    protected void customizeImage(Path image) throws Exception {
         Path bundle = image.resolve(getBundleName() + ".app");
         Path contents = bundle.resolve("Contents");
         Path resources = contents.resolve("Resources");
@@ -79,12 +78,10 @@ class AppBundleTask extends AbstractPackagerTask {
         setupLauncherSource(image);
         setupSigningConfiguration(image, bundle);
         
-        return image;
-        
     }
     
     @Override
-    public Path createPackage(Path image) throws Exception {
+    protected Path buildPackage(Path image) throws Exception {
         Path bundle = image.resolve(getBundleName() + ".app");
         
         String execName = FileUtils.find(bundle, "Contents/Resources/*/bin/*")

--- a/src/main/java/org/apache/netbeans/nbpackage/macos/PkgTask.java
+++ b/src/main/java/org/apache/netbeans/nbpackage/macos/PkgTask.java
@@ -34,13 +34,13 @@ class PkgTask extends AppBundleTask {
     }
     
     @Override
-    public void validateCreatePackage() throws Exception {
-        super.validateCreatePackage();
+    protected void checkPackageRequirements() throws Exception {
+        super.checkPackageRequirements();
         validateTools("pkgbuild");
     }
 
     @Override
-    public Path createPackage(Path image) throws Exception {
+    protected Path buildPackage(Path image) throws Exception {
         Path bundle = super.createPackage(image);
         String name = context().getValue(NBPackage.PACKAGE_NAME).orElseThrow();
         String version = context().getValue(NBPackage.PACKAGE_VERSION).orElseThrow();

--- a/src/main/java/org/apache/netbeans/nbpackage/macos/PkgTask.java
+++ b/src/main/java/org/apache/netbeans/nbpackage/macos/PkgTask.java
@@ -74,8 +74,8 @@ class PkgTask extends AppBundleTask {
     }
 
     @Override
-    protected String imageName(Path input) throws Exception {
-        return super.imageName(input) + "-pkg";
+    protected String calculateImageName(Path input) throws Exception {
+        return super.calculateImageName(input) + "-pkg";
     }
 
 }

--- a/src/main/java/org/apache/netbeans/nbpackage/macos/PkgTask.java
+++ b/src/main/java/org/apache/netbeans/nbpackage/macos/PkgTask.java
@@ -41,7 +41,7 @@ class PkgTask extends AppBundleTask {
 
     @Override
     protected Path buildPackage(Path image) throws Exception {
-        Path bundle = super.createPackage(image);
+        Path bundle = super.buildPackage(image);
         String name = context().getValue(NBPackage.PACKAGE_NAME).orElseThrow();
         String version = context().getValue(NBPackage.PACKAGE_VERSION).orElseThrow();
         Path output = context().destination().resolve(

--- a/src/main/java/org/apache/netbeans/nbpackage/rpm/RpmTask.java
+++ b/src/main/java/org/apache/netbeans/nbpackage/rpm/RpmTask.java
@@ -47,21 +47,19 @@ class RpmTask extends AbstractPackagerTask {
     }
 
     @Override
-    public void validateCreateImage() throws Exception {
-        super.validateCreateImage();
+    protected void checkImageRequirements() throws Exception {
         if (context().isImageOnly()) {
             validateTools(RPM);
         }
     }
 
     @Override
-    public void validateCreatePackage() throws Exception {
+    protected void checkPackageRequirements() throws Exception {
         validateTools(RPM, RPMBUILD);
     }
 
     @Override
-    public Path createImage(Path input) throws Exception {
-        Path image = super.createImage(input);
+    protected void customizeImage(Path image) throws Exception {
         String pkgName = packageName();
 
         // @TODO support other installation bases
@@ -98,11 +96,10 @@ class RpmTask extends AbstractPackagerTask {
         Files.createDirectories(specsDir);
         setupSpecFile(specsDir, execName, desktopFile.getFileName().toString());
 
-        return image;
     }
 
     @Override
-    public Path createPackage(Path image) throws Exception {
+    protected Path buildPackage(Path image) throws Exception {
         Path spec = image.resolve("SPECS").resolve(packageName() + ".spec");
         int result = context().exec(RPMBUILD, "--target", packageArch(),
                 "--define", "_topdir " + image.toAbsolutePath().toString(),

--- a/src/main/java/org/apache/netbeans/nbpackage/rpm/RpmTask.java
+++ b/src/main/java/org/apache/netbeans/nbpackage/rpm/RpmTask.java
@@ -123,12 +123,12 @@ class RpmTask extends AbstractPackagerTask {
     }
 
     @Override
-    protected String imageName(Path input) throws Exception {
+    protected String calculateImageName(Path input) throws Exception {
         return packageName() + "-" + packageVersion() + "." + packageArch();
     }
 
     @Override
-    protected Path applicationDirectory(Path image) throws Exception {
+    protected Path calculateAppPath(Path image) throws Exception {
         return image.resolve("usr").resolve("lib").resolve("APPDIR");
     }
 

--- a/src/main/java/org/apache/netbeans/nbpackage/zip/ZipPackageTask.java
+++ b/src/main/java/org/apache/netbeans/nbpackage/zip/ZipPackageTask.java
@@ -43,11 +43,11 @@ class ZipPackageTask extends AbstractPackagerTask {
     }
 
     @Override
-    protected Path runtimeDirectory(Path image, Path application) throws Exception {
+    protected Path calculateRuntimePath(Path image, Path application) throws Exception {
         if (Files.exists(application.resolve("bin").resolve("netbeans"))) {
             context().warningHandler().accept(ZipPackager.MESSAGES.getString("zip.nbruntime.warning"));
         }
-        return super.runtimeDirectory(image, application);
+        return super.calculateRuntimePath(image, application);
     }
 
 }

--- a/src/main/java/org/apache/netbeans/nbpackage/zip/ZipPackageTask.java
+++ b/src/main/java/org/apache/netbeans/nbpackage/zip/ZipPackageTask.java
@@ -16,13 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-
-
 package org.apache.netbeans.nbpackage.zip;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
 import org.apache.netbeans.nbpackage.AbstractPackagerTask;
 import org.apache.netbeans.nbpackage.ExecutionContext;
 import org.apache.netbeans.nbpackage.FileUtils;
@@ -34,15 +31,15 @@ class ZipPackageTask extends AbstractPackagerTask {
     }
 
     @Override
-    public Path createPackage(Path image) throws Exception {
-        Path dst = context().destination().resolve(image.getFileName().toString() + ".zip");
-        FileUtils.createZipArchive(image, dst);
-        return dst;
+    protected void customizeImage(Path image) throws Exception {
+        // no op
     }
 
     @Override
-    public void validateCreatePackage() throws Exception {
-        // no op
+    protected Path buildPackage(Path image) throws Exception {
+        Path dst = context().destination().resolve(image.getFileName().toString() + ".zip");
+        FileUtils.createZipArchive(image, dst);
+        return dst;
     }
 
     @Override
@@ -52,7 +49,5 @@ class ZipPackageTask extends AbstractPackagerTask {
         }
         return super.runtimeDirectory(image, application);
     }
-    
-    
 
 }

--- a/src/main/resources/org/apache/netbeans/nbpackage/Messages.properties
+++ b/src/main/resources/org/apache/netbeans/nbpackage/Messages.properties
@@ -58,3 +58,6 @@ message.creatingimage=Building image from {0}.
 message.creatingpackage=Building package from {0}.
 message.outputcreated=Successfully built {0}.
 message.version=Apache NetBeans NBPackage version {0}
+message.mergingfile=Merging file {0} to {1}.
+message.mergingdir=Merging directory {0} to {1}.
+message.removing=Removing file {0}.

--- a/src/main/resources/org/apache/netbeans/nbpackage/Messages.properties
+++ b/src/main/resources/org/apache/netbeans/nbpackage/Messages.properties
@@ -37,6 +37,8 @@ option.runtime.help=Path to Java runtime to include in the package (default none
 option.description.help=A single-line description of the package. Not all packagers will display this.
 option.publisher.help=Application publisher. Not all packagers will display this.
 option.url.help=Link to application / publisher website. Not all packagers will display this.
+option.merge.help=Path to directory or zip of additional files to merge into image before package building.
+option.remove.help=Glob pattern of files to remove from the image before package building.
 
 # Option defaults
 option.description.default=Package of ${package.name} ${package.version}.

--- a/src/main/resources/org/apache/netbeans/nbpackage/rpm/rpm.spec.template
+++ b/src/main/resources/org/apache/netbeans/nbpackage/rpm/rpm.spec.template
@@ -20,8 +20,4 @@ AutoReqProv:    no
 ${RPM_DESCRIPTION}
 
 %files
-/usr/bin/${RPM_EXEC_NAME}
-/usr/lib/%{name}
-/usr/share/applications/${RPM_DESKTOP_NAME}
-/usr/share/icons/hicolor/48x48/apps/%{name}.png
-/usr/share/icons/hicolor/scalable/apps/%{name}.svg
+${RPM_FILES}

--- a/src/test/java/org/apache/netbeans/nbpackage/AbstractPackagerTaskTest.java
+++ b/src/test/java/org/apache/netbeans/nbpackage/AbstractPackagerTaskTest.java
@@ -195,7 +195,7 @@ public class AbstractPackagerTaskTest {
             }
 
             @Override
-            protected Path applicationDirectory(Path image) throws Exception {
+            protected Path calculateAppPath(Path image) throws Exception {
                 return image.resolve("BUILD").resolve("usr").resolve("lib").resolve("app");
             }
 

--- a/src/test/java/org/apache/netbeans/nbpackage/AbstractPackagerTaskTest.java
+++ b/src/test/java/org/apache/netbeans/nbpackage/AbstractPackagerTaskTest.java
@@ -1,0 +1,171 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.netbeans.nbpackage;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.function.Function;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Various tests for {@link AbstractPackagerTask}.
+ */
+public class AbstractPackagerTaskTest {
+
+    private static Path tmpDir;
+    private static Path input;
+    private static Path runtime;
+
+    public AbstractPackagerTaskTest() {
+    }
+
+    @BeforeAll
+    public static void setUpClass() throws IOException {
+        tmpDir = Files.createTempDirectory("nbp-task-tests-");
+        Path appRoot = Files.createDirectory(tmpDir.resolve("appDir"));
+        Path appBin = Files.createDirectory(appRoot.resolve("bin"));
+        Path appEtc = Files.createDirectory(appRoot.resolve("etc"));
+        Path platform = Files.createDirectory(appRoot.resolve("platform"));
+        Files.createFile(appBin.resolve("app"));
+        Files.createFile(appEtc.resolve("app.conf"));
+        Files.createFile(platform.resolve("module"));
+        input = tmpDir.resolve("app.zip");
+        FileUtils.createZipArchive(appRoot, input);
+        Path jdkRoot = Files.createDirectory(tmpDir.resolve("jdkDir"));
+        Path jdkBin = Files.createDirectory(jdkRoot.resolve("bin"));
+        Files.createFile(jdkBin.resolve("java"));
+        runtime = tmpDir.resolve("runtime.zip");
+        FileUtils.createZipArchive(jdkRoot, runtime);
+    }
+
+    @AfterAll
+    public static void tearDownClass() throws IOException {
+        if (tmpDir != null) {
+            FileUtils.deleteFiles(tmpDir);
+            tmpDir = null;
+        }
+    }
+
+    /**
+     * Test extraction of the input zip to create a base image.
+     */
+    @Test
+    public void testCreateBaseImage() throws Exception {
+        Configuration config = Configuration.builder()
+                .set(NBPackage.PACKAGE_NAME, "App")
+                .build();
+        Path output = Files.createDirectory(tmpDir.resolve("baseOnlyOutput"));
+        class TestTask extends AbstractPackagerTask {
+
+            public TestTask(ExecutionContext context) {
+                super(context);
+            }
+
+            @Override
+            protected Path buildPackage(Path image) throws Exception {
+                throw new IllegalStateException();
+            }
+
+            @Override
+            protected void customizeImage(Path image) throws Exception {
+            }
+
+        }
+        ExecutionContext context = new ExecutionContext(
+                new TestPackager("Test Base Only", TestTask::new),
+                input,
+                config,
+                output,
+                true);
+        Path image = context.execute();
+        assertEquals(output, image.getParent());
+        assertTrue(Files.exists(image.resolve("bin").resolve("app")));
+        assertTrue(Files.exists(image.resolve("etc").resolve("app.conf")));
+        assertTrue(Files.exists(image.resolve("platform").resolve("module")));
+        assertFalse(Files.exists(image.resolve("jdk")));
+    }
+    
+    /**
+     * Test extraction of the input zip and runtime zip to create a base image.
+     */
+    @Test
+    public void testCreateBaseImageWithRuntime() throws Exception {
+        Configuration config = Configuration.builder()
+                .set(NBPackage.PACKAGE_NAME, "App")
+                .set(NBPackage.PACKAGE_RUNTIME, runtime.toString())
+                .build();
+        Path output = Files.createDirectory(tmpDir.resolve("baseAndRuntimeOutput"));
+        class TestTask extends AbstractPackagerTask {
+
+            public TestTask(ExecutionContext context) {
+                super(context);
+            }
+
+            @Override
+            protected Path buildPackage(Path image) throws Exception {
+                throw new IllegalStateException();
+            }
+
+            @Override
+            protected void customizeImage(Path image) throws Exception {
+            }
+
+        }
+        ExecutionContext context = new ExecutionContext(
+                new TestPackager("Test Base with Runtime", TestTask::new),
+                input,
+                config,
+                output,
+                true);
+        Path image = context.execute();
+        assertEquals(output, image.getParent());
+        assertTrue(Files.exists(image.resolve("bin").resolve("app")));
+        assertTrue(Files.exists(image.resolve("etc").resolve("app.conf")));
+        assertTrue(Files.exists(image.resolve("platform").resolve("module")));
+        assertTrue(Files.exists(image.resolve("jdk").resolve("bin").resolve("java")));
+    }
+
+    private static class TestPackager implements Packager {
+
+        private final String name;
+        private final Function<ExecutionContext, Task> taskCreator;
+
+        private TestPackager(String name, Function<ExecutionContext, Task> taskCreator) {
+            this.name = name;
+            this.taskCreator = taskCreator;
+        }
+
+        @Override
+        public Task createTask(ExecutionContext context) {
+            return taskCreator.apply(context);
+        }
+
+        @Override
+        public String name() {
+            return name;
+        }
+
+    }
+
+}

--- a/src/test/java/org/apache/netbeans/nbpackage/AbstractPackagerTaskTest.java
+++ b/src/test/java/org/apache/netbeans/nbpackage/AbstractPackagerTaskTest.java
@@ -153,9 +153,6 @@ public class AbstractPackagerTaskTest {
                 .resolve("share").resolve("applications").resolve("app.desktop");
         Files.createDirectories(desktopFile.getParent());
         Files.createFile(desktopFile);
-        Path batFile = root.resolve("__APP").resolve("bin").resolve("app.bat");
-        Files.createDirectories(batFile.getParent());
-        Files.createFile(batFile);
         Path buildFile = root.resolve("config").resolve("build");
         Files.createDirectories(buildFile.getParent());
         Files.createFile(buildFile);
@@ -200,7 +197,7 @@ public class AbstractPackagerTaskTest {
             }
 
             @Override
-            protected Path calculateRootPath(Path image, Path application) throws Exception {
+            protected Path calculateRootPath(Path image) throws Exception {
                 return image.resolve("BUILD");
             }
 
@@ -214,7 +211,6 @@ public class AbstractPackagerTaskTest {
         Path image = context.execute();
         Path appDir = image.resolve("BUILD").resolve("usr").resolve("lib").resolve("app");
         assertTrue(Files.exists(appDir.resolve("bin").resolve("app")));
-        assertTrue(Files.exists(appDir.resolve("bin").resolve("app.bat")));
         assertTrue(Files.exists(appDir.resolve("bin").resolve("LEAVE_ME.exe")));
         assertFalse(Files.exists(appDir.resolve("bin").resolve("REMOVE_ME.exe")));
         assertFalse(Files.exists(appDir.resolve("platform")));


### PR DESCRIPTION
Added support for a merge source (archive or directory) to add files to an image, and a glob pattern to remove files from an image.

In order to support filtering (merging / deleting files) of the image after customization, I needed to refactor the abstract task into separate template steps / hooks.  Good to do this now before we reach v1!

Steps that require a file list are moved into the finalization step.  The RPM task is changed to generate the file list for the spec file from the actual contents, which also fixes cases where the application doesn't supply an svg icon.

Added a few tests for AbstractPackagerTask.  Need to consider how best to add tests for the actual packager implementations in future.