### PR TITLE
Fix stack overflow in Deb packager task

### DIFF
--- a/src/main/java/org/apache/netbeans/nbpackage/deb/DebTask.java
+++ b/src/main/java/org/apache/netbeans/nbpackage/deb/DebTask.java
@@ -50,7 +50,6 @@ class DebTask extends AbstractPackagerTask {
 
     @Override
     protected void checkImageRequirements() throws Exception {
-        super.validateCreateImage();
         if (context().isImageOnly()) {
             validateTools(DPKG);
         }


### PR DESCRIPTION
Fix stack overflow in Deb packager task caused by non-removed call super method.

Accidentally got left in during refactoring and missed in local testing.  Need to see about testing actual packagers in GitHub actions too.