### PR TITLE
Fix InvalidPathException issue on Windows in FileUtils::findDirs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,16 +24,20 @@ on:
     types: [opened, synchronize, unlocked]
 
 jobs:
-  build:
-
-    runs-on: ubuntu-latest
+  linux-build:
+    name: Build and test on ${{ matrix.os }}, JDK ${{ matrix.java }}
+    strategy:
+      matrix:
+        java: [ '11', '17' ]
+        os: [ 'ubuntu-latest', 'windows-latest', 'macos-latest' ]
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 11
+    - name: Set up JDK 
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: ${{ matrix.java }}
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven

--- a/src/main/java/org/apache/netbeans/nbpackage/FileUtils.java
+++ b/src/main/java/org/apache/netbeans/nbpackage/FileUtils.java
@@ -229,8 +229,15 @@ public class FileUtils {
     /**
      * Find the directories in the given search directory that contains files
      * that match the given glob patterns. This might include the search
-     * directory itself. eg. to find NetBeans or a RCP application in a search
-     * directory you might pass <code>"bin/*", "etc/*.conf"</code>.
+     * directory itself. eg. to find the root directory of NetBeans or a RCP
+     * application in a search directory you might pass
+     * <code>"bin/*", "etc/*.conf"</code>.
+     * <p>
+     * All patterns should use <code>/</code> as the separator character, and
+     * should not use <code>**</code>, the boundary crossing wildcard. The
+     * search depth parameter controls the maximum depth of any potential root
+     * directory. The maximum path depth of all patterns is used to control how
+     * deep the search is <em>within</em> each potential root.
      *
      * @param searchDir search directory
      * @param searchDepth search depth
@@ -243,8 +250,8 @@ public class FileUtils {
                 .map(p -> FileSystems.getDefault().getPathMatcher("glob:" + p))
                 .collect(Collectors.toList());
         var intDepth = Stream.of(patterns)
-                .map(Path::of)
-                .mapToInt(Path::getNameCount)
+                .map(p -> p.split("/"))
+                .mapToInt(ps -> ps.length)
                 .max().orElse(1);
         try (var stream = Files.find(searchDir, searchDepth, (intPath, attr) -> {
             return matchers.stream().map(m -> {


### PR DESCRIPTION
FileUtils::findDirs is breaking on Windows as it's using `Path` to calculate the max path depth for the passed in glob patterns, and `*` is not supported in a Windows path.  Switches to using `String::split`.

First commit adds a workflow matrix to build and run unit tests on Linux, Windows and macOS.

Fixes #28 