### PR TITLE
Remove debugging output from Windows launcher.

### DIFF
--- a/src/assembly/bin/nbpackage.cmd
+++ b/src/assembly/bin/nbpackage.cmd
@@ -63,9 +63,6 @@ goto repoSetup
 
 :WinNTGetScriptDir
 for %%i in ("%~dp0..") do set "BASEDIR=%%~fi"
-echo %~dp0
-echo %~dp0..
-echo %BASEDIR%
 
 :repoSetup
 set REPO=


### PR DESCRIPTION
While testing functionality on Windows I noticed that some debugging output had been left in the launch script.