### PR TITLE
Set topSiteUrl to stop site:stage building in root directory.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -210,6 +210,13 @@ under the License.
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <configuration>
+          <topSiteURL>${project.distributionManagement.site.url}</topSiteURL>
+        </configuration>
+      </plugin>
     </plugins>
     <resources>
       <resource>


### PR DESCRIPTION
Set topSiteUrl to stop site:stage building in root directory. See https://issues.apache.org/jira/projects/MSITE/issues/MSITE-948