### PR TITLE
better rendering for site

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@ under the License.
   <packaging>jar</packaging>
   
   <name>Apache NetBeans NBPackage</name>
-  <url>https://netbeans.apache.org</url>
+  <url>https://bits.netbeans.org/nbpackage/</url>
   <description>Apache NetBeans packaging utility.</description>
   
   <scm>
@@ -213,6 +213,7 @@ under the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
+        <version>4.0.0-M9</version>
         <configuration>
           <topSiteURL>${project.distributionManagement.site.url}</topSiteURL>
         </configuration>
@@ -237,5 +238,8 @@ under the License.
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <junit.jupiter.version>5.9.3</junit.jupiter.version>
+    <skin.groupId>org.apache.maven.skins</skin.groupId>
+    <skin.artifactId>maven-fluido-skin</skin.artifactId>
+    <skin.version>2.0.0-M6</skin.version>
   </properties>
 </project>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/DECORATION/1.8.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/DECORATION/1.8.0 https://maven.apache.org/xsd/decoration-1.8.0.xsd" combine.self="override">
+    <skin>
+        <groupId>${skin.groupId}</groupId>
+        <artifactId>${skin.artifactId}</artifactId>
+        <version>${skin.version}</version>
+    </skin>
+    <publishDate position="none"/>
+    <version position="none"/>
+    <body>
+        <menu>
+            <item name="Apache NetBeans home" href="https://netbeans.apache.org "/>
+        </menu>
+        <menu ref="reports" />
+    </body>
+    <custom>
+        <fluidoSkin>
+            <skipGenerationDate>true</skipGenerationDate>
+            <gitHub>
+                <projectId>apache/netbeans-nbpackage</projectId>
+                <ribbonOrientation>right</ribbonOrientation>
+                <ribbonColor>black</ribbonColor>
+            </gitHub>
+        </fluidoSkin>
+    </custom>
+</project>


### PR DESCRIPTION
The website is created at https://bits.netbeans.org/nbpackage/index.html .
But looks so vintage that I port the nbm-maven plugin site to nbpackage.

For the future, would like to put site version+ skin version in parent pom so "all" the maven project are a bit related in skin.
Will also add the "asciidoc" plugin so we edit adoc everywhere including netbeans-website.