### PR TITLE
Add FlatLaf to the default list of JARs with macOS natives.

### DIFF
--- a/src/main/java/org/apache/netbeans/nbpackage/macos/MacOS.java
+++ b/src/main/java/org/apache/netbeans/nbpackage/macos/MacOS.java
@@ -29,7 +29,7 @@ import org.apache.netbeans.nbpackage.Template;
 class MacOS {
 
     private static final String DEFAULT_BIN_GLOB = "{*.dylib,*.jnilib,**/nativeexecution/MacOSX-*/*,Contents/Home/bin/*,Contents/Home/lib/jspawnhelper}";
-    private static final String DEFAULT_JAR_BIN_GLOB = "{jna-5*.jar,junixsocket-native-common-*.jar,launcher-common-*.jar,jansi-*.jar,nbi-engine.jar}";
+    private static final String DEFAULT_JAR_BIN_GLOB = "{flatlaf*.jar,jna-5*.jar,junixsocket-native-common-*.jar,launcher-common-*.jar,jansi-*.jar,nbi-engine.jar}";
 
     static final ResourceBundle MESSAGES
             = ResourceBundle.getBundle(PkgPackager.class.getPackageName() + ".Messages");


### PR DESCRIPTION
Add FlatLaf to the default list of JARs with macOS native libraries that need signing.  FlatLaf 3.3 introduced in https://github.com/apache/netbeans/pull/6948 includes native libraries for macOS.  If these are not extracted, signed and repackaged in the JAR, the resulting bundle and installer will fail Apple notarization.  This is despite the binaries being extracted in the build and loaded from elsewhere during IDE execution.  The extracted libraries are also signed by NBPackage, but already picked up by the default search pattern.