### PR TITLE
Add Truffle runtime to list of JARs containing native macOS binaries.

### DIFF
--- a/src/main/java/org/apache/netbeans/nbpackage/macos/MacOS.java
+++ b/src/main/java/org/apache/netbeans/nbpackage/macos/MacOS.java
@@ -29,7 +29,7 @@ import org.apache.netbeans.nbpackage.Template;
 class MacOS {
 
     private static final String DEFAULT_BIN_GLOB = "{*.dylib,*.jnilib,**/nativeexecution/MacOSX-*/*,Contents/Home/bin/*,Contents/Home/lib/jspawnhelper}";
-    private static final String DEFAULT_JAR_BIN_GLOB = "{flatlaf*.jar,jna-5*.jar,junixsocket-native-common-*.jar,launcher-common-*.jar,jansi-*.jar,nbi-engine.jar}";
+    private static final String DEFAULT_JAR_BIN_GLOB = "{flatlaf-*.jar,jna-5*.jar,junixsocket-native-common-*.jar,launcher-common-*.jar,jansi-*.jar,nbi-engine.jar,truffle-runtime-*.jar}";
 
     static final ResourceBundle MESSAGES
             = ResourceBundle.getBundle(PkgPackager.class.getPackageName() + ".Messages");


### PR DESCRIPTION
Following upgrade of Truffle runtime in IDE we need to add this to the list of JARs containing macOS native binaries so that the libraries are extracted, signed and repackaged.  Otherwise, the macOS pkg fails Apple notarization and cannot be distributed.

Also see https://github.com/apache/netbeans/pull/7268