### PR TITLE
Replace hyphens with tilde in DEB and RPM version strings.

### DIFF
--- a/.github/scripts/PackageTest.java
+++ b/.github/scripts/PackageTest.java
@@ -155,7 +155,7 @@ public final class PackageTest {
         cmd.add("--input");
         cmd.add(input.toString());
         cmd.add("-Pname=NetBeans RCP");
-        cmd.add("-Pversion=12.3~rc4");
+        cmd.add("-Pversion=12.3-rc4");
         cmd.add("-Pruntime=" + runtime.toString());
         if ("windows-innosetup".equals(type)) {
             cmd.add("-Pinnosetup.tool=" + System.getenv("INNOSETUP_PATH"));

--- a/src/main/java/org/apache/netbeans/nbpackage/deb/DebTask.java
+++ b/src/main/java/org/apache/netbeans/nbpackage/deb/DebTask.java
@@ -182,7 +182,7 @@ class DebTask extends AbstractPackagerTask {
 
     private String sanitizeVersion(String text) {
         return text.toLowerCase(Locale.ROOT)
-                .replaceAll("[^a-z0-9\\+\\-\\.\\~]", "-");
+                .replaceAll("[^a-z0-9\\+\\.\\~]", "~");
     }
 
     private Path findLauncher(Path binDir) throws IOException {

--- a/src/main/java/org/apache/netbeans/nbpackage/rpm/RpmTask.java
+++ b/src/main/java/org/apache/netbeans/nbpackage/rpm/RpmTask.java
@@ -217,7 +217,7 @@ class RpmTask extends AbstractPackagerTask {
 
     private String sanitizeVersion(String text) {
         return text.toLowerCase(Locale.ROOT)
-                .replaceAll("[^a-z0-9\\+\\-\\.\\~]", "-");
+                .replaceAll("[^a-z0-9\\+\\.\\~]", "~");
     }
 
     private Path findLauncher(Path binDir) throws IOException {


### PR DESCRIPTION
Replace hyphens and other sanitized characters in the version String with `~`.  An RPM fails to build with a hyphen in the version.  The DEB will build, but has other issues, including version sorting (RCs marked later than releases).

Closes #94 