### PR TITLE
Add basic image generation tests for main packagers.

### DIFF
--- a/src/main/java/org/apache/netbeans/nbpackage/deb/DebTask.java
+++ b/src/main/java/org/apache/netbeans/nbpackage/deb/DebTask.java
@@ -199,7 +199,11 @@ class DebTask extends AbstractPackagerTask {
                 Map.of("PACKAGE", packageLocation, "EXEC", execName));
         Path bin = binDir.resolve(execName);
         Files.writeString(bin, script, StandardOpenOption.CREATE_NEW);
-        Files.setPosixFilePermissions(bin, PosixFilePermissions.fromString("rwxr-xr-x"));
+        try {
+            Files.setPosixFilePermissions(bin, PosixFilePermissions.fromString("rwxr-xr-x"));
+        } catch (UnsupportedOperationException ex) {
+            context().warningHandler().accept("UnsupportedOperationException : PosixFilePermissions");
+        }
     }
 
     private void setupIcons(Path share, String pkgName) throws IOException {

--- a/src/main/java/org/apache/netbeans/nbpackage/rpm/RpmTask.java
+++ b/src/main/java/org/apache/netbeans/nbpackage/rpm/RpmTask.java
@@ -54,13 +54,6 @@ class RpmTask extends AbstractPackagerTask {
     }
 
     @Override
-    protected void checkImageRequirements() throws Exception {
-        if (context().isImageOnly()) {
-            validateTools(RPM);
-        }
-    }
-
-    @Override
     protected void checkPackageRequirements() throws Exception {
         validateTools(RPM, RPMBUILD);
     }
@@ -234,7 +227,11 @@ class RpmTask extends AbstractPackagerTask {
                 Map.of("PACKAGE", packageLocation, "EXEC", execName));
         Path bin = binDir.resolve(execName);
         Files.writeString(bin, script, StandardOpenOption.CREATE_NEW);
-        Files.setPosixFilePermissions(bin, PosixFilePermissions.fromString("rwxr-xr-x"));
+        try {
+            Files.setPosixFilePermissions(bin, PosixFilePermissions.fromString("rwxr-xr-x"));
+        } catch (UnsupportedOperationException ex) {
+            context().warningHandler().accept("UnsupportedOperationException : PosixFilePermissions");
+        }
     }
 
     private void setupIcons(Path share, String pkgName) throws IOException {

--- a/src/test/java/org/apache/netbeans/nbpackage/AbstractPackagerTaskTest.java
+++ b/src/test/java/org/apache/netbeans/nbpackage/AbstractPackagerTaskTest.java
@@ -22,9 +22,10 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.function.Function;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.CleanupMode;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -33,7 +34,7 @@ import static org.junit.jupiter.api.Assertions.*;
  */
 public class AbstractPackagerTaskTest {
 
-    private static Path tmpDir;
+    private static @TempDir(cleanup = CleanupMode.ON_SUCCESS) Path tmpDir;
     private static Path input;
     private static Path runtime;
 
@@ -42,29 +43,12 @@ public class AbstractPackagerTaskTest {
 
     @BeforeAll
     public static void setUpClass() throws IOException {
-        tmpDir = Files.createTempDirectory("nbp-task-tests-");
-        Path appRoot = Files.createDirectory(tmpDir.resolve("appDir"));
-        Path appBin = Files.createDirectory(appRoot.resolve("bin"));
-        Path appEtc = Files.createDirectory(appRoot.resolve("etc"));
-        Path platform = Files.createDirectory(appRoot.resolve("platform"));
-        Files.createFile(appBin.resolve("app"));
-        Files.createFile(appEtc.resolve("app.conf"));
-        Files.createFile(platform.resolve("module"));
+        Path appRoot = TestUtils.buildFakeApp(tmpDir, "appDir", "app");
         input = tmpDir.resolve("app.zip");
         FileUtils.createZipArchive(appRoot, input);
-        Path jdkRoot = Files.createDirectory(tmpDir.resolve("jdkDir"));
-        Path jdkBin = Files.createDirectory(jdkRoot.resolve("bin"));
-        Files.createFile(jdkBin.resolve("java"));
+        Path jdkRoot = TestUtils.buildFakeJDK(tmpDir, "jdkDir", false);
         runtime = tmpDir.resolve("runtime.zip");
         FileUtils.createZipArchive(jdkRoot, runtime);
-    }
-
-    @AfterAll
-    public static void tearDownClass() throws IOException {
-        if (tmpDir != null) {
-            FileUtils.deleteFiles(tmpDir);
-            tmpDir = null;
-        }
     }
 
     /**

--- a/src/test/java/org/apache/netbeans/nbpackage/TestUtils.java
+++ b/src/test/java/org/apache/netbeans/nbpackage/TestUtils.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.netbeans.nbpackage;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Utility methods for tests.
+ */
+public class TestUtils {
+
+    private TestUtils() {
+    }
+
+    /**
+     * Build a fake application structure, providing the files required by any
+     * packager. The directory must not already exist.
+     *
+     * @param parent parent directory
+     * @param dirname name of the created directory
+     * @param branding branding token of application
+     * @return created directory
+     * @throws java.io.IOException
+     */
+    public static Path buildFakeApp(Path parent, String dirname, String branding)
+            throws IOException {
+        Path dir = Files.createDirectory(parent.resolve(dirname));
+        Path appBin = Files.createDirectory(dir.resolve("bin"));
+        Path appEtc = Files.createDirectory(dir.resolve("etc"));
+        Path platform = Files.createDirectory(dir.resolve("platform"));
+        Files.createFile(appBin.resolve(branding));
+        Files.createFile(appBin.resolve(branding + ".exe"));
+        Files.createFile(appBin.resolve(branding + "64.exe"));
+        Files.createFile(appEtc.resolve(branding + ".conf"));
+        Files.createFile(platform.resolve("module"));
+        return dir;
+    }
+
+    /**
+     * Build a fake JDK structure, providing the files required by any packager.
+     * The directory must not already exist.
+     *
+     * @param parent parent directory
+     * @param dirname name of the created directory
+     * @param windows whether files should have .exe suffix
+     * @return created directory
+     * @throws java.io.IOException
+     */
+    public static Path buildFakeJDK(Path parent, String dirname, boolean windows)
+            throws IOException {
+        Path dir = Files.createDirectory(parent.resolve(dirname));
+        Path jdkBin = Files.createDirectory(dir.resolve("bin"));
+        if (windows) {
+            Files.createFile(jdkBin.resolve("java.exe"));
+        } else {
+            Files.createFile(jdkBin.resolve("java"));
+        }
+        return dir;
+    }
+
+    /**
+     * Build an image using the provided packager and configuration.
+     *
+     * @param packager packager to use
+     * @param input input application
+     * @param config configuration
+     * @param destination output directory (image parent)
+     * @return path to created image
+     * @throws Exception
+     */
+    public static Path buildImage(Packager packager, Path input,
+            Configuration config, Path destination) throws Exception {
+        ExecutionContext exec = new ExecutionContext(
+                packager, input, config, destination, true);
+        return exec.execute();
+    }
+
+    /**
+     * Utility to resolve paths.
+     *
+     * @param path root path
+     * @param fragments path fragments
+     * @return resolved path
+     */
+    public static Path resolve(Path path, String... fragments) {
+        Path result = path;
+        for (String fragment : fragments) {
+            result = result.resolve(fragment);
+        }
+        return result;
+    }
+
+}

--- a/src/test/java/org/apache/netbeans/nbpackage/deb/DebPackagerTest.java
+++ b/src/test/java/org/apache/netbeans/nbpackage/deb/DebPackagerTest.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.netbeans.nbpackage.deb;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.netbeans.nbpackage.Configuration;
+import org.apache.netbeans.nbpackage.FileUtils;
+import org.apache.netbeans.nbpackage.NBPackage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.CleanupMode;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.apache.netbeans.nbpackage.TestUtils.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for DebPackager.
+ */
+public class DebPackagerTest {
+    
+    private @TempDir(cleanup = CleanupMode.ON_SUCCESS) Path tmpDir;
+    
+    @Test
+    public void testImageWithoutRuntime() throws Exception {
+        Path input = tmpDir.resolve("App-1.0-b1.zip");
+        FileUtils.createZipArchive(
+                buildFakeApp(tmpDir, "App-1.0-b1", "app"),
+                input);
+        Configuration config = Configuration.builder()
+                .set(NBPackage.PACKAGE_NAME, "App")
+                .set(NBPackage.PACKAGE_VERSION, "1.0-b1")
+                .build();
+        Path image = buildImage(new DebPackager(), input, config, tmpDir);
+        assertTrue(image.getFileName().toString().endsWith("_all"));
+        String control = Files.readString(resolve(image, "DEBIAN", "control"));
+        assertTrue(control.contains("Package: app"));
+        assertTrue(control.contains("Recommends: java17-sdk"));
+        assertTrue(Files.exists(resolve(image, "usr", "bin", "app")));
+        assertTrue(Files.exists(resolve(image, "usr", "share", "applications", "app.desktop")));
+        assertTrue(Files.exists(resolve(image, "usr", "share", "icons", "hicolor", "48x48", "apps", "app.png")));
+        assertTrue(Files.exists(resolve(image, "usr", "share", "icons", "hicolor", "scalable", "apps", "app.svg")));
+    }
+    
+    @Test
+    public void testImageWithX86_64Runtime() throws Exception {
+        Path input = tmpDir.resolve("App-1.0-b1.zip");
+        FileUtils.createZipArchive(
+                buildFakeApp(tmpDir, "App-1.0-b1", "app"),
+                input);
+        String runtimeName = "OpenJDK24U-jdk_x64_linux_hotspot_24.0.1_9";
+        Path runtime = tmpDir.resolve(runtimeName + ".zip");
+        FileUtils.createZipArchive(
+                buildFakeJDK(tmpDir, runtimeName, false),
+                runtime);
+        Configuration config = Configuration.builder()
+                .set(NBPackage.PACKAGE_NAME, "App")
+                .set(NBPackage.PACKAGE_VERSION, "1.0-b1")
+                .set(NBPackage.PACKAGE_RUNTIME, runtime.toString())
+                .build();
+        Path image = buildImage(new DebPackager(), input, config, tmpDir);
+        assertTrue(image.getFileName().toString().endsWith("_amd64"));
+        String control = Files.readString(resolve(image, "DEBIAN", "control"));
+        assertTrue(control.contains("Package: app"));
+        assertFalse(control.contains("Recommends: java"));
+        assertTrue(Files.exists(resolve(image, "usr", "bin", "app")));
+        assertTrue(Files.exists(resolve(image, "usr", "lib", "app", "jdk", "bin", "java")));
+        assertTrue(Files.exists(resolve(image, "usr", "share", "applications", "app.desktop")));
+        assertTrue(Files.exists(resolve(image, "usr", "share", "icons", "hicolor", "48x48", "apps", "app.png")));
+        assertTrue(Files.exists(resolve(image, "usr", "share", "icons", "hicolor", "scalable", "apps", "app.svg")));
+    }
+
+}

--- a/src/test/java/org/apache/netbeans/nbpackage/innosetup/InnoSetupPackagerTest.java
+++ b/src/test/java/org/apache/netbeans/nbpackage/innosetup/InnoSetupPackagerTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.netbeans.nbpackage.innosetup;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.netbeans.nbpackage.Configuration;
+import org.apache.netbeans.nbpackage.FileUtils;
+import org.apache.netbeans.nbpackage.NBPackage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.CleanupMode;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.apache.netbeans.nbpackage.TestUtils.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for InnoSetupPackager.
+ */
+public class InnoSetupPackagerTest {
+
+    private @TempDir(cleanup = CleanupMode.ON_SUCCESS) Path tmpDir;
+
+    @Test
+    public void testImageWithoutRuntime() throws Exception {
+        Path input = tmpDir.resolve("App-1.0-b1.zip");
+        FileUtils.createZipArchive(
+                buildFakeApp(tmpDir, "App-1.0-b1", "app"),
+                input);
+        Configuration config = Configuration.builder()
+                .set(NBPackage.PACKAGE_NAME, "App")
+                .set(NBPackage.PACKAGE_VERSION, "1.0-b1")
+                .build();
+        Path image = buildImage(new InnoSetupPackager(), input, config, tmpDir);
+        assertTrue(Files.exists(resolve(image, "app.iss")));
+        assertTrue(Files.exists(resolve(image, "app", "bin", "app64.exe")));
+        assertTrue(Files.exists(resolve(image, "app", "etc", "app.ico")));
+    }
+
+    @Test
+    public void testImageWithX86_64Runtime() throws Exception {
+        Path input = tmpDir.resolve("App-1.0-b1.zip");
+        FileUtils.createZipArchive(
+                buildFakeApp(tmpDir, "App-1.0-b1", "app"),
+                input);
+        String runtimeName = "OpenJDK24U-jdk_x64_windows_hotspot_24.0.1_9";
+        Path runtime = tmpDir.resolve(runtimeName + ".zip");
+        FileUtils.createZipArchive(
+                buildFakeJDK(tmpDir, runtimeName, true),
+                runtime);
+        Configuration config = Configuration.builder()
+                .set(NBPackage.PACKAGE_NAME, "App")
+                .set(NBPackage.PACKAGE_VERSION, "1.0-b1")
+                .set(NBPackage.PACKAGE_RUNTIME, runtime.toString())
+                .build();
+        Path image = buildImage(new InnoSetupPackager(), input, config, tmpDir);
+        assertTrue(Files.exists(resolve(image, "app.iss")));
+        assertTrue(Files.exists(resolve(image, "app", "bin", "app64.exe")));
+        assertTrue(Files.exists(resolve(image, "app", "etc", "app.ico")));
+        assertTrue(Files.exists(resolve(image, "app", "jdk", "bin", "java.exe")));
+    }
+
+}

--- a/src/test/java/org/apache/netbeans/nbpackage/macos/PkgPackagerTest.java
+++ b/src/test/java/org/apache/netbeans/nbpackage/macos/PkgPackagerTest.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.netbeans.nbpackage.macos;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.netbeans.nbpackage.Configuration;
+import org.apache.netbeans.nbpackage.FileUtils;
+import org.apache.netbeans.nbpackage.NBPackage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.CleanupMode;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.apache.netbeans.nbpackage.TestUtils.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for PkgPackager.
+ */
+public class PkgPackagerTest {
+
+    private @TempDir(cleanup = CleanupMode.ON_SUCCESS) Path tmpDir;
+
+    @Test
+    public void testImageWithoutRuntime() throws Exception {
+        Path input = tmpDir.resolve("App-1.0-b1.zip");
+        FileUtils.createZipArchive(
+                buildFakeApp(tmpDir, "App-1.0-b1", "app"),
+                input);
+        Configuration config = Configuration.builder()
+                .set(NBPackage.PACKAGE_NAME, "App")
+                .set(NBPackage.PACKAGE_VERSION, "1.0-b1")
+                .build();
+        Path image = buildImage(new PkgPackager(), input, config, tmpDir);
+        Path app = resolve(image, "App.app");
+        assertTrue(Files.isDirectory(app));
+        assertTrue(Files.isDirectory(resolve(image, "macos-launcher-src")));
+        assertTrue(Files.exists(resolve(image, "jarBinaries")));
+        assertTrue(Files.exists(resolve(image, "nativeBinaries")));
+        assertTrue(Files.exists(resolve(image, "sandbox.plist")));
+        assertTrue(Files.exists(resolve(app, "Contents", "Info.plist")));
+        assertFalse(Files.exists(resolve(app, "Contents", "Home")));
+        assertTrue(Files.exists(resolve(app, "Contents", "Resources", "app.icns")));
+        assertTrue(Files.exists(resolve(app, "Contents", "Resources", "app", "bin", "app")));
+    }
+
+    @Test
+    public void testImageWithX86_64Runtime() throws Exception {
+        Path input = tmpDir.resolve("App-1.0-b1.zip");
+        FileUtils.createZipArchive(
+                buildFakeApp(tmpDir, "App-1.0-b1", "app"),
+                input);
+        String runtimeName = "OpenJDK24U-jdk_aarch64_mac_hotspot_24.0.1_9";
+        Path runtime = tmpDir.resolve(runtimeName + ".zip");
+        FileUtils.createZipArchive(
+                buildFakeJDK(tmpDir, runtimeName, false),
+                runtime);
+        Configuration config = Configuration.builder()
+                .set(NBPackage.PACKAGE_NAME, "App")
+                .set(NBPackage.PACKAGE_VERSION, "1.0-b1")
+                .set(NBPackage.PACKAGE_RUNTIME, runtime.toString())
+                .build();
+        Path image = buildImage(new PkgPackager(), input, config, tmpDir);
+        assertTrue(image.getFileName().toString().contains("arm64"));
+        Path app = resolve(image, "App.app");
+        assertTrue(Files.isDirectory(app));
+        assertTrue(Files.isDirectory(resolve(image, "macos-launcher-src")));
+        assertTrue(Files.exists(resolve(image, "jarBinaries")));
+        assertTrue(Files.exists(resolve(image, "nativeBinaries")));
+        assertTrue(Files.exists(resolve(image, "sandbox.plist")));
+        assertTrue(Files.exists(resolve(app, "Contents", "Info.plist")));
+        assertTrue(Files.exists(resolve(app, "Contents", "Home", "bin", "java")));
+        assertTrue(Files.exists(resolve(app, "Contents", "Resources", "app.icns")));
+        assertTrue(Files.exists(resolve(app, "Contents", "Resources", "app", "bin", "app")));
+    }
+
+}

--- a/src/test/java/org/apache/netbeans/nbpackage/rpm/RpmPackagerTest.java
+++ b/src/test/java/org/apache/netbeans/nbpackage/rpm/RpmPackagerTest.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.netbeans.nbpackage.rpm;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.apache.netbeans.nbpackage.Configuration;
+import org.apache.netbeans.nbpackage.FileUtils;
+import org.apache.netbeans.nbpackage.NBPackage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.CleanupMode;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.apache.netbeans.nbpackage.TestUtils.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for RpmPackager.
+ */
+public class RpmPackagerTest {
+
+    private @TempDir(cleanup = CleanupMode.ON_SUCCESS) Path tmpDir;
+
+    @Test
+    public void testImageWithoutRuntime() throws Exception {
+        Path input = tmpDir.resolve("App-1.0-b1.zip");
+        FileUtils.createZipArchive(
+                buildFakeApp(tmpDir, "App-1.0-b1", "app"),
+                input);
+        Configuration config = Configuration.builder()
+                .set(NBPackage.PACKAGE_NAME, "App")
+                .set(NBPackage.PACKAGE_VERSION, "1.0-b1")
+                .build();
+        Path image = buildImage(new RpmPackager(), input, config, tmpDir);
+        assertTrue(image.getFileName().toString().endsWith(".noarch"));
+        assertTrue(Files.exists(resolve(image, "SPECS", "app.spec")));
+        Path root = resolve(image, "BUILDROOT", "app-1.0~b1-0.noarch");
+        assertTrue(Files.exists(resolve(root, "usr", "bin", "app")));
+        assertTrue(Files.exists(resolve(root, "usr", "share", "applications", "app.desktop")));
+        assertTrue(Files.exists(resolve(root, "usr", "share", "icons", "hicolor", "48x48", "apps", "app.png")));
+        assertTrue(Files.exists(resolve(root, "usr", "share", "icons", "hicolor", "scalable", "apps", "app.svg")));
+    }
+
+    @Test
+    public void testImageWithX86_64Runtime() throws Exception {
+        Path input = tmpDir.resolve("App-1.0-b1.zip");
+        FileUtils.createZipArchive(
+                buildFakeApp(tmpDir, "App-1.0-b1", "app"),
+                input);
+        String runtimeName = "OpenJDK24U-jdk_x64_linux_hotspot_24.0.1_9";
+        Path runtime = tmpDir.resolve(runtimeName + ".zip");
+        FileUtils.createZipArchive(
+                buildFakeJDK(tmpDir, runtimeName, false),
+                runtime);
+        Configuration config = Configuration.builder()
+                .set(NBPackage.PACKAGE_NAME, "App")
+                .set(NBPackage.PACKAGE_VERSION, "1.0-b1")
+                .set(NBPackage.PACKAGE_RUNTIME, runtime.toString())
+                .build();
+        Path image = buildImage(new RpmPackager(), input, config, tmpDir);
+        assertTrue(image.getFileName().toString().endsWith(".x86_64"));
+        assertTrue(Files.exists(resolve(image, "SPECS", "app.spec")));
+        Path root = resolve(image, "BUILDROOT", "app-1.0~b1-0.x86_64");
+        assertTrue(Files.exists(resolve(root, "usr", "bin", "app")));
+        assertTrue(Files.exists(resolve(root, "usr", "lib", "app", "jdk", "bin", "java")));
+        assertTrue(Files.exists(resolve(root, "usr", "share", "applications", "app.desktop")));
+        assertTrue(Files.exists(resolve(root, "usr", "share", "icons", "hicolor", "48x48", "apps", "app.png")));
+        assertTrue(Files.exists(resolve(root, "usr", "share", "icons", "hicolor", "scalable", "apps", "app.svg")));
+    }
+
+}


### PR DESCRIPTION
Add basic image generation tests for the main packagers.  This PR also fixes a couple of issues with running image generation across all platforms (posix permissions / rpm requirement left in by mistake).

More could be done to validate each image, but these tests cover the basic structure, and ensure the image creation actually runs, which will help with future development.

AppImage left out for now as this needs some consideration due to upstream changes there.