### PR TITLE
Update Maven and build dependencies

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -14,6 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+wrapperVersion=3.3.4
 distributionType=only-script
-distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.11/apache-maven-3.9.11-bin.zip
-distributionSha256Sum=0d7125e8c91097b36edb990ea5934e6c68b4440eef4ea96510a0f6815e7eeadb
+distributionUrl=https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.16/apache-maven-3.9.16-bin.zip
+distributionSha256Sum=5af3b743dd8b876b5c45da33b676251e5f1687712644abb4ee519ca56e1d89ce

--- a/mvnw
+++ b/mvnw
@@ -19,7 +19,7 @@
 # ----------------------------------------------------------------------------
 
 # ----------------------------------------------------------------------------
-# Apache Maven Wrapper startup batch script, version 3.3.3
+# Apache Maven Wrapper startup batch script, version 3.3.4
 #
 # Optional ENV vars
 # -----------------

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -19,7 +19,7 @@
 @REM ----------------------------------------------------------------------------
 
 @REM ----------------------------------------------------------------------------
-@REM Apache Maven Wrapper startup batch script, version 3.3.3
+@REM Apache Maven Wrapper startup batch script, version 3.3.4
 @REM
 @REM Optional ENV vars
 @REM   MVNW_REPOURL - repo url base for downloading maven distribution

--- a/pom.xml
+++ b/pom.xml
@@ -89,13 +89,18 @@ under the License.
             <release>21</release>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.apache.rat</groupId>
+          <artifactId>apache-rat-plugin</artifactId>
+          <version>0.18</version>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.14.1</version>
+        <version>3.15.0</version>
         <configuration>
           <release>21</release>
           <compilerArgs>
@@ -108,24 +113,24 @@ under the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.5.4</version>
+        <version>3.5.5</version>
       </plugin>
       <plugin>
         <groupId>org.apache.rat</groupId>
         <artifactId>apache-rat-plugin</artifactId>
         <configuration>
-          <excludes>
+          <inputExcludes>
             <!-- exclude template files - no creativity; currently no way to filter out license --> 
-            <exclude>**/*.template</exclude>
+            <inputExclude>**/*.template</inputExclude>
             <!-- exclude Apache NetBeans SVG - license header causes display issues on certain OS -->
-            <exclude>**/apache-netbeans.svg</exclude>
+            <inputExclude>**/apache-netbeans.svg</inputExclude>
             <!-- exclude NetBeans configuration files, not in source bundle -->
-            <exclude>nbactions.xml</exclude>
-            <exclude>nb-configuration.xml</exclude>
+            <inputExclude>nbactions.xml</inputExclude>
+            <inputExclude>nb-configuration.xml</inputExclude>
             <!-- misc excludes -->
-            <exclude>README.md</exclude>
-            <exclude>src/assembly/bin/BINARY_NOTICE</exclude>
-          </excludes>
+            <inputExclude>README.md</inputExclude>
+            <inputExclude>src/assembly/bin/BINARY_NOTICE</inputExclude>
+          </inputExcludes>
         </configuration>
         <executions>
           <execution>
@@ -243,7 +248,7 @@ under the License.
  
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <junit.jupiter.version>6.0.2</junit.jupiter.version>
+    <junit.jupiter.version>6.0.3</junit.jupiter.version>
     <skin.groupId>org.apache.maven.skins</skin.groupId>
     <skin.artifactId>maven-fluido-skin</skin.artifactId>
     <skin.version>2.0.0-M8</skin.version>


### PR DESCRIPTION
Update to Maven 3.9.16
Update to Maven Compiler Plugin 3.15.0
Update to Maven Surefire Plugin 3.5.5
Update to JUnit Jupiter 6.0.3
Update to Apache Rat 0.18 and fix configuration due to build warnings

Taking over from dependabot to get a few extra things in! :smile: 